### PR TITLE
Fix Rover Portal registration link

### DIFF
--- a/site/rover/business-suite/portal/README.md
+++ b/site/rover/business-suite/portal/README.md
@@ -12,7 +12,7 @@ This document is intended for users of the Zumasys' Rover Portal, i.e. customers
 ## Registration Steps
 
 1. [Contact Us](mailto:accounting@zumasys.com) to set up your contact information.
-2. Visit <a href="hub.zumasys.com">hub.zumasys.com</a> and click on the Register link.
+2. Visit <a href="https://hub.zumasys.com">hub.zumasys.com</a> and click on the Register link.
 3. Make sure the username is the email we set up for you as the contact.
 4. Once finished, click register and you will be forwarded to your profile.
 


### PR DESCRIPTION
## Summary
- fix broken registration link to hub.zumasys.com

## Testing
- `npm run build` *(fails: vuepress not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849ccf7b458832d891bdea2caa221d8