### PR TITLE
Fix indefinite coupon expiration text

### DIFF
--- a/site/rover/MRK-OVERVIEW/MRK-ENTRY/COUPON-E/COUPON-E-1/README.md
+++ b/site/rover/MRK-OVERVIEW/MRK-ENTRY/COUPON-E/COUPON-E-1/README.md
@@ -17,8 +17,8 @@ sequential number.
 the coupon is effective immediately.  
   
 **Exp Date** Enter the expiration date of the coupon. If no date is entered,
-the coupon is effective indefinately or until maximum number of uses has been
-reached.  
+the coupon is effective indefinitely or until maximum number of uses has been
+reached.
   
 **Inactive** Check this box to inactivate this coupon.  
   


### PR DESCRIPTION
## Summary
- correct typo in coupon expiration explanation in COUPON-E-1 README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6882839385b083308c3b1dd84b23e8e6